### PR TITLE
Include top-level Python modules in wheel builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,12 @@ from setuptools import setup
 from setuptools_rust import Binding, RustExtension
 
 setup(
+    py_modules=[
+        "geohash",
+        "quadtree",
+        "jpgrid",
+        "jpiarea",
+    ],
 	# Source builds stay interpreter-specific; wheel builds request cp38-abi3 below.
 	rust_extensions=[
 		RustExtension('_geohash', 'Cargo.toml', binding=Binding.PyO3, py_limited_api="auto")


### PR DESCRIPTION
Fixes #47

This change explicitly includes the project's top-level Python modules during wheel generation.

The source tree contains:

* geohash.py
* quadtree.py
* jpgrid.py
* jpiarea.py

and `pyproject.toml` declares:

```toml
[tool.setuptools]
py-modules = ["geohash", "quadtree", "jpgrid", "jpiarea"]
```

However, the published 0.9.0 wheel does not contain these modules.

Published 0.9.0 wheel contents:

```text
_geohash/__init__.py
_geohash/_geohash.abi3.so
```

Expected modules missing from the wheel:

```text
geohash.py
quadtree.py
jpgrid.py
jpiarea.py
```

As a result:

```python
import geohash
```

fails with:

```text
ModuleNotFoundError: No module named 'geohash'
```

This change makes inclusion of the top-level Python modules explicit in `setup.py`.

Verification performed:

1. Built a wheel using:

```bash
python -m build
```

2. Confirmed the resulting wheel contains:

```text
_geohash.abi3.so
geohash.py
quadtree.py
jpgrid.py
jpiarea.py
```

3. Installed the wheel into a clean virtual environment and verified the following imports succeed:

```python
import geohash
import quadtree
import jpgrid
import jpiarea
import _geohash
```